### PR TITLE
fix: sails.config.sockets.onlyAllowOrigins issue

### DIFF
--- a/.sailsrc
+++ b/.sailsrc
@@ -7,6 +7,7 @@
     "sails-generate": "1.16.13"
   },
   "hooks": {
+    "sockets" : false,
     "session": false,
     "views": false,
     "security": false


### PR DESCRIPTION
error solved: No sails.config.sockets.onlyAllowOrigins or sails.config.sockets.beforeConnect setting was detected.